### PR TITLE
very slight improvement in duplicate test speed

### DIFF
--- a/A11yUITests/Classes/A11yTests.swift
+++ b/A11yUITests/Classes/A11yTests.swift
@@ -129,7 +129,7 @@ internal extension XCTestCase {
 
         guard element1.isControl,
               element2.isControl,
-              element1.underlyingElement != element2.underlyingElement else { return }
+              element1.id != element2.id else { return }
 
         XCTAssertFalse(element1.label == element2.label,
                        "Accessibility Failure: Elements have duplicated labels: \(element1.description), \(element2.description)",

--- a/A11yUITests/Classes/Elements/A11yElement.swift
+++ b/A11yUITests/Classes/Elements/A11yElement.swift
@@ -12,6 +12,7 @@ struct A11yElement {
     let frame: CGRect
     let type: XCUIElement.ElementType
     let underlyingElement: XCUIElement
+    let id = UUID()
 
     var shouldIgnore: Bool {
         return self.type == .window ||


### PR DESCRIPTION
Comparing A11yElement UUID instead of underlying elements when doing duplicate checks.
Shortens the `all` test in the example by ~3ms.