### PR TITLE
Updating to reference to CoreGraphics directly instead (Foundation is not importing it for some reason)

### DIFF
--- a/A11yUITests.podspec
+++ b/A11yUITests.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'A11yUITests'
-  s.version          = '0.5.0'
+  s.version          = '0.5.1'
   s.summary          = 'Accessibility tests for XCUI Testing.'
 
   s.description      = <<-DESC

--- a/Sources/A11yUITests/Tests/Values.swift
+++ b/Sources/A11yUITests/Tests/Values.swift
@@ -5,7 +5,7 @@
 //  Created by Rob Whitaker on 19/04/2021.
 //
 
-import Foundation
+import CoreGraphics
 
 public struct A11yValues {
     public static let minSize = 14


### PR DESCRIPTION
This fixes #30 

This replaces the Foundation reference for a direct CoreGraphics reference since Foundation (with XCode 12.4, targets of iOS 11-14) doesn't seem to include CoreGraphics anymore. 🤷 