### PR TITLE
More explicit size test failure message

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,10 @@ let package = Package(
             dependencies: [],
             path: "Sources/A11yUITests"
         ),
+        .testTarget(
+          name: "A11yPackageTests",
+          dependencies: ["A11yUITests"]
+        )
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Sources/A11yUITests/Extensions/CGFloat+IsMoreThanOrEqual.swift
+++ b/Sources/A11yUITests/Extensions/CGFloat+IsMoreThanOrEqual.swift
@@ -1,0 +1,18 @@
+//
+//  AssertGreaterThan.swift
+//  A11yUITests
+//
+//  Created by Ryan Ferrell at SeedFi on 10/08/2022.
+//
+
+import Foundation
+
+extension CGFloat {
+
+  func isMoreThanOrEqual(
+    to targetValue: CGFloat,
+    tolerance: CGFloat = 0
+  ) -> Bool {
+    self >= (targetValue - abs(tolerance))
+  }
+}

--- a/Sources/A11yUITests/Tests/A11yAssertions.swift
+++ b/Sources/A11yUITests/Tests/A11yAssertions.swift
@@ -22,25 +22,31 @@ final class A11yAssertions {
 
         guard !element.shouldIgnore else { return }
 
-        let minFloatSize = CGFloat(minSize)
+      let height = element.frame.size.height
+      let width = element.frame.size.width
+      let minimumSize = A11yValues.minInteractiveSize
 
-        let heightDifference = element.frame.size.height - minFloatSize
-        XCTAssertGreaterThanOrEqual(heightDifference,
-                                    -A11yValues.floatComparisonTolerance,
-                                    Failure.warning.report("Element not tall enough",
-                                                           element,
-                                                           reason: "Minimum size: \(minSize)"),
-                                    file: file,
-                                    line: line)
+      let tolerance = A11yValues.floatComparisonTolerance
+      let isValidHeight = height.isMoreThanOrEqual(to: minimumSize, tolerance: tolerance)
+      let isValidWidth = width.isMoreThanOrEqual(to: minimumSize, tolerance: tolerance)
 
-        let widthDifference = element.frame.size.width - minFloatSize
-        XCTAssertGreaterThanOrEqual(widthDifference,
-                                    -A11yValues.floatComparisonTolerance,
-                                    Failure.warning.report("Element not wide enough",
-                                                           element,
-                                                           reason: "Minimum size: \(minSize)"),
-                                    file: file,
-                                    line: line)
+      if !isValidHeight {
+        let message = Failure.warning.report(
+          "Element too short",
+          element,
+          reason: "Minimum: \(minimumSize). Current: \(height)"
+        )
+        _XCTPreformattedFailureHandler(nil, false, String(file), Int(line), message, "")
+      }
+
+      if !isValidWidth {
+        let message = Failure.warning.report(
+          "Element too narrow",
+          element,
+          reason: "Minimum: \(minimumSize). Current: \(height)"
+        )
+        _XCTPreformattedFailureHandler(nil, false, String(file), Int(line), message, "")
+      }
     }
 
     func validLabelFor(_ element: A11yElement,
@@ -206,21 +212,31 @@ final class A11yAssertions {
         if (!allElements && !interactiveElement.isInteractive) ||
             !interactiveElement.isControl { return }
 
-        let heightDifference = interactiveElement.frame.size.height - A11yValues.minInteractiveSize
-        XCTAssertGreaterThanOrEqual(heightDifference,
-                                    -A11yValues.floatComparisonTolerance,
-                                    Failure.failure.report("Interactive element not tall enough",
-                                                           interactiveElement),
-                                    file: file,
-                                    line: line)
+      let height = interactiveElement.frame.size.height
+      let width = interactiveElement.frame.size.width
+      let minimumSize = A11yValues.minInteractiveSize
 
-        let widthDifference = interactiveElement.frame.size.width - A11yValues.minInteractiveSize
-        XCTAssertGreaterThanOrEqual(widthDifference,
-                                    -A11yValues.floatComparisonTolerance,
-                                    Failure.failure.report("Interactive element not wide enough",
-                                                           interactiveElement),
-                                    file: file,
-                                    line: line)
+      let tolerance = A11yValues.floatComparisonTolerance
+      let isValidHeight = height.isMoreThanOrEqual(to: minimumSize, tolerance: tolerance)
+      let isValidWidth = width.isMoreThanOrEqual(to: minimumSize, tolerance: tolerance)
+
+      if !isValidHeight {
+        let message = Failure.failure.report(
+          "Interactive element too short",
+          interactiveElement,
+          reason: "Minimum: \(minimumSize). Current: \(height)"
+        )
+        _XCTPreformattedFailureHandler(nil, false, String(file), Int(line), message, "")
+      }
+
+      if !isValidWidth {
+        let message = Failure.failure.report(
+          "Interactive element too narrow",
+          interactiveElement,
+          reason: "Minimum: \(minimumSize). Current: \(height)"
+        )
+        _XCTPreformattedFailureHandler(nil, false, String(file), Int(line), message, "")
+      }
     }
 
     func hasHeader(_ element: A11yElement) {

--- a/Tests/A11yPackageTests/AssertGreaterThanTests.swift
+++ b/Tests/A11yPackageTests/AssertGreaterThanTests.swift
@@ -1,0 +1,74 @@
+//
+//  AssertGreaterThan.swift
+//  A11yUITests
+//
+//  Created by Ryan Ferrell at SeedFi on 10/08/2022.
+//
+
+import XCTest
+@testable import A11yUITests
+
+final class AssertGreaterThanTests: XCTestCase {
+
+  func testPassesExactValues() {
+    let testCases = [CGFloat.zero, .init(A11yValues.minSize), 100.0]
+    let tolerance = 0.0
+    testCases.forEach { value in
+      let result = value.isMoreThanOrEqual(to: value, tolerance: tolerance)
+      XCTAssertTrue(result, "\(value)")
+    }
+  }
+
+  func testFailsNonExactValues() {
+    let testCases = [CGFloat.zero, .init(A11yValues.minSize), 100.0]
+    let tolerance = 0.0
+    let offset = 1.0
+
+    testCases.forEach { value in
+      let offsetValue = value + offset
+      let result = value.isMoreThanOrEqual(to: offsetValue, tolerance: tolerance)
+      XCTAssertFalse(result, "\(value)")
+    }
+  }
+
+  func testPassesGreaterValues() {
+    let testCases = [CGFloat.zero, .init(A11yValues.minSize), 100.0]
+    let tolerance = A11yValues.floatComparisonTolerance
+
+    testCases.forEach { value in
+      let offsetValue = value + tolerance / 2
+      let result = offsetValue.isMoreThanOrEqual(to: value, tolerance: tolerance)
+      XCTAssertTrue(result, "Within tolerance: \(value)")
+    }
+
+    testCases.forEach { value in
+      let offsetValue = value + tolerance * 2
+      let result = offsetValue.isMoreThanOrEqual(to: value, tolerance: tolerance)
+      XCTAssertTrue(result, "Beyond tolerance: \(value)")
+    }
+  }
+
+  func testPassesLesserValues_WithinTolerance() {
+    let testCases = [CGFloat.zero, .init(A11yValues.minSize), 100.0]
+    let tolerance = A11yValues.floatComparisonTolerance
+    let offset = A11yValues.floatComparisonTolerance / 2
+
+    testCases.forEach { value in
+      let offsetValue = value + offset
+      let result = value.isMoreThanOrEqual(to: offsetValue, tolerance: tolerance)
+      XCTAssertTrue(result, "\(value)")
+    }
+  }
+
+  func testFailsLesserValues_OutsideTolerance() {
+    let testCases = [CGFloat.zero, .init(A11yValues.minSize), 100.0]
+    let tolerance = A11yValues.floatComparisonTolerance
+    let offset = A11yValues.floatComparisonTolerance * 2
+
+    testCases.forEach { value in
+      let offsetValue = value + offset
+      let result = value.isMoreThanOrEqual(to: offsetValue, tolerance: tolerance)
+      XCTAssertFalse(result, "\(value)")
+    }
+  }
+}


### PR DESCRIPTION
Minor addition of a minimum size failure message that's a little more descriptive about the element tested.

Previous:

<img width="482" alt="Screen Shot 2022-10-10 at 9 47 36 AM" src="https://user-images.githubusercontent.com/78187398/194900759-cd9c4f98-6935-4119-b4f1-e6d38603a3b0.png">

Proposed:

<img width="839" alt="Screen Shot 2022-10-10 at 11 29 39 AM" src="https://user-images.githubusercontent.com/78187398/194902432-f2c4d4d1-1f1d-463c-8029-41ef28d931fd.png">

