### PR TITLE
snapshot crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added the ability to specify accessibility label or accessibility identifier reported in failure messages
 * New rule for elements with a placeholder and no label.
 * Improved method for fetching traits meaning no swizzling - thank you [Chris Kolbu](https://github.com/nesevis)
+* Fixed a crash when performing a snapshot test on a screen with fewer elements that the reference
 
 ## 1.0.0
 

--- a/Sources/A11yUITests/Tests/A11ySnapshot.swift
+++ b/Sources/A11yUITests/Tests/A11ySnapshot.swift
@@ -169,7 +169,11 @@ final class A11ySnapshot {
             return
         }
 
+        XCTAssertEqual(reference.snapshot.count, snapshot.snapshot.count, Failure.failure.report("Snapshots contain a different number of items. This screen has changed."), file: file, line: line)
+
         for i in 0..<reference.snapshot.count {
+
+            guard snapshot.snapshot.count > i else { return }
 
             let snapshotElement = snapshot.snapshot[i]
             let referenceElement = reference.snapshot[i]


### PR DESCRIPTION
Fixed a crash when performing a snapshot test on a screen with fewer elements that the reference